### PR TITLE
added no upgrade flag to robotpy sync

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Sync robotpy
         working-directory: ./src
         run: |
-          python3 -m robotpy sync
+          python3 -m robotpy sync --no-upgrade-project
       - name: Install dependencies
         run: |
           python3 -m pip install ruff


### PR DESCRIPTION
### 🛠 Proposed Changes:

Added `--no-upgrade-project` flag to workflow
### 📝 Details:

Was causing the workflow to fail.